### PR TITLE
Add CI build workflow and badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+      - name: Build plugin
+        run: |
+          yarn install
+          yarn build --production

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YouTrack Fetcher
 
+[![Build status](https://github.com/forketyfork/obsidian-youtrack-fetcher/actions/workflows/build.yml/badge.svg)](https://github.com/forketyfork/obsidian-youtrack-fetcher/actions/workflows/build.yml)
+
 This Obsidian plugin allows you to quickly fetch YouTrack issues and create notes from them in your Obsidian vault.
 
 ## Features


### PR DESCRIPTION
## Summary
- add a build workflow for pushes
- show build status badge in README

## Testing
- `node_modules/.bin/tsc -noEmit -skipLibCheck`
- `node_modules/.bin/prettier --write README.md .github/workflows/build.yml`
- `yarn build` *(fails: connect ETIMEDOUT)*