### PR TITLE
Parse fields from template on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Obsidian plugin allows you to quickly fetch YouTrack issues and create note
 - Configurable folder for storing issue notes
 - Configurable note template
 - Use `${field}` placeholders in templates to insert values from fetched fields
-- Customizable list of issue fields to fetch
+- Fields to fetch are parsed from your template automatically
 
 ## Installation
 
@@ -56,7 +56,7 @@ URL: ${url}
 ${description}
 ```
 
-Any field listed in **Issue fields** setting can be used as a placeholder with `${field}`.
+Any field referenced in the template can be used as a placeholder with `${field}`.
 
 The issue `summary` can also be used as a `${title}` placeholder.
 

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -15,6 +15,6 @@ describe("YouTrackPlugin", () => {
 		expect(plugin.settings.apiToken).toBe("");
 		expect(plugin.settings.useApiToken).toBe(false);
 		expect(plugin.settings.notesFolder).toBe("YouTrack");
-               expect(plugin.settings.templatePath).toBe("");
+		expect(plugin.settings.templatePath).toBe("");
 	});
 });

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -15,7 +15,6 @@ describe("YouTrackPlugin", () => {
 		expect(plugin.settings.apiToken).toBe("");
 		expect(plugin.settings.useApiToken).toBe(false);
 		expect(plugin.settings.notesFolder).toBe("YouTrack");
-		expect(plugin.settings.templatePath).toBe("");
-		expect(plugin.settings.fields).toBe("summary,description");
+               expect(plugin.settings.templatePath).toBe("");
 	});
 });

--- a/__tests__/template.test.ts
+++ b/__tests__/template.test.ts
@@ -7,20 +7,20 @@ describe("YouTrackPlugin Template Rendering", () => {
 		plugin = new YouTrackPlugin({} as any, {} as any);
 		// Set fixed locale and time zone for stable tests
 		plugin.dateTimeOptions = {
-			locale: 'en-US',
-			timeZone: 'UTC'
+			locale: "en-US",
+			timeZone: "UTC",
 		};
 	});
 
 	describe("renderTemplate", () => {
 		test("should render template with all issue fields", () => {
-                       plugin.settings = {
-                               youtrackUrl: "",
-                               apiToken: "",
-                               useApiToken: false,
-                               notesFolder: "",
-                               templatePath: "",
-                       };
+			plugin.settings = {
+				youtrackUrl: "",
+				apiToken: "",
+				useApiToken: false,
+				notesFolder: "",
+				templatePath: "",
+			};
 
 			// Sample YouTrack issue data
 			const issueData = {

--- a/__tests__/template.test.ts
+++ b/__tests__/template.test.ts
@@ -14,14 +14,13 @@ describe("YouTrackPlugin Template Rendering", () => {
 
 	describe("renderTemplate", () => {
 		test("should render template with all issue fields", () => {
-			plugin.settings = {
-				youtrackUrl: "",
-				apiToken: "",
-				useApiToken: false,
-				notesFolder: "",
-				templatePath: "",
-				fields: "summary,description,created,updated,resolved",
-			};
+                       plugin.settings = {
+                               youtrackUrl: "",
+                               apiToken: "",
+                               useApiToken: false,
+                               notesFolder: "",
+                               templatePath: "",
+                       };
 
 			// Sample YouTrack issue data
 			const issueData = {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -7,30 +7,30 @@ describe("YouTrackPlugin Utils", () => {
 		plugin = new YouTrackPlugin({} as any, {} as any);
 		// Set fixed locale and time zone for stable tests
 		plugin.dateTimeOptions = {
-			locale: 'en-US',
-			timeZone: 'UTC'
+			locale: "en-US",
+			timeZone: "UTC",
 		};
 	});
 
-describe("parseFieldListFromTemplate", () => {
-       test("should return empty list for template without fields", () => {
-               const template = "# ${id}\nURL: ${url}";
-               const result = plugin.parseFieldListFromTemplate(template);
-               expect(result).toEqual([]);
-       });
+	describe("parseFieldListFromTemplate", () => {
+		test("should return empty list for template without fields", () => {
+			const template = "# ${id}\nURL: ${url}";
+			const result = plugin.parseFieldListFromTemplate(template);
+			expect(result).toEqual([]);
+		});
 
-       test("should collect unique fields", () => {
-               const template = "${created} ${updated} ${created}";
-               const result = plugin.parseFieldListFromTemplate(template);
-               expect(result).toEqual(["created", "updated"]);
-       });
+		test("should collect unique fields", () => {
+			const template = "${created} ${updated} ${created}";
+			const result = plugin.parseFieldListFromTemplate(template);
+			expect(result).toEqual(["created", "updated"]);
+		});
 
-       test("should map title to summary and ignore id and url", () => {
-               const template = "# ${id}: ${title} (${url})";
-               const result = plugin.parseFieldListFromTemplate(template);
-               expect(result).toEqual(["summary"]);
-       });
-});
+		test("should map title to summary and ignore id and url", () => {
+			const template = "# ${id}: ${title} (${url})";
+			const result = plugin.parseFieldListFromTemplate(template);
+			expect(result).toEqual(["summary"]);
+		});
+	});
 
 	describe("formatTimestamp", () => {
 		test("should format valid timestamp number", () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -12,52 +12,25 @@ describe("YouTrackPlugin Utils", () => {
 		};
 	});
 
-	describe("parseFieldListFromSettings", () => {
-		test("should handle empty fields string", () => {
-			plugin.settings = {
-				youtrackUrl: "",
-				apiToken: "",
-				useApiToken: false,
-				notesFolder: "",
-				templatePath: "",
-				fields: "",
-			};
+describe("parseFieldListFromTemplate", () => {
+       test("should return empty list for template without fields", () => {
+               const template = "# ${id}\nURL: ${url}";
+               const result = plugin.parseFieldListFromTemplate(template);
+               expect(result).toEqual([]);
+       });
 
-			const result = plugin.parseFieldListFromSettings();
+       test("should collect unique fields", () => {
+               const template = "${created} ${updated} ${created}";
+               const result = plugin.parseFieldListFromTemplate(template);
+               expect(result).toEqual(["created", "updated"]);
+       });
 
-			expect(result).toEqual([]);
-		});
-
-		test("should remove whitespace from fields", () => {
-			plugin.settings = {
-				youtrackUrl: "",
-				apiToken: "",
-				useApiToken: false,
-				notesFolder: "",
-				templatePath: "",
-				fields: "summary, description,  created  ,updated",
-			};
-
-			const result = plugin.parseFieldListFromSettings();
-
-			expect(result).toEqual(["summary", "description", "created", "updated"]);
-		});
-
-		test("should filter out empty fields", () => {
-			plugin.settings = {
-				youtrackUrl: "",
-				apiToken: "",
-				useApiToken: false,
-				notesFolder: "",
-				templatePath: "",
-				fields: "summary,,description, ,created",
-			};
-
-			const result = plugin.parseFieldListFromSettings();
-
-			expect(result).toEqual(["summary", "description", "created"]);
-		});
-	});
+       test("should map title to summary and ignore id and url", () => {
+               const template = "# ${id}: ${title} (${url})";
+               const result = plugin.parseFieldListFromTemplate(template);
+               expect(result).toEqual(["summary"]);
+       });
+});
 
 	describe("formatTimestamp", () => {
 		test("should format valid timestamp number", () => {

--- a/main.ts
+++ b/main.ts
@@ -135,22 +135,17 @@ export default class YouTrackPlugin extends Plugin {
 	// Parse list of fields referenced in a template
 	parseFieldListFromTemplate(template: string): string[] {
 		const fields = new Set<string>();
-		const regex = /\$\{([^}]+)\}/g;
-		let match: RegExpExecArray | null;
-		while ((match = regex.exec(template)) !== null) {
+		const matches = template.matchAll(/\$\{([^}]+)\}/g);
+
+		for (const match of matches) {
 			const field = match[1].trim();
-			if (!field || field === "id" || field === "url") {
-				continue;
-			}
-			if (field === "title") {
-				fields.add("summary");
-			} else {
-				fields.add(field);
-			}
+			if (!field || field === "id" || field === "url") continue;
+
+			fields.add(field === "title" ? "summary" : field);
 		}
+
 		return Array.from(fields);
 	}
-
 	formatTimestamp(value: unknown): string {
 		const date = typeof value === "number" ? new Date(value) : new Date(String(value));
 		if (isNaN(date.getTime())) {

--- a/main.ts
+++ b/main.ts
@@ -11,19 +11,19 @@ import {
 } from "obsidian";
 
 interface YouTrackPluginSettings {
-       youtrackUrl: string;
-       apiToken: string;
-       useApiToken: boolean;
-       notesFolder: string;
-       templatePath: string;
+	youtrackUrl: string;
+	apiToken: string;
+	useApiToken: boolean;
+	notesFolder: string;
+	templatePath: string;
 }
 
 const DEFAULT_SETTINGS: YouTrackPluginSettings = {
 	youtrackUrl: "https://youtrack.jetbrains.com",
 	apiToken: "",
-        useApiToken: false,
-        notesFolder: "YouTrack",
-        templatePath: "",
+	useApiToken: false,
+	notesFolder: "YouTrack",
+	templatePath: "",
 };
 
 const DEFAULT_TEMPLATE = "# ${id}: ${title}\n\nURL: ${url}\n\n## Description\n\n${description}\n";
@@ -39,7 +39,7 @@ export default class YouTrackPlugin extends Plugin {
 	settings: YouTrackPluginSettings;
 	dateTimeOptions: DateTimeFormatOptions = {
 		locale: undefined, // Uses system locale by default
-		timeZone: undefined // Uses system time zone by default
+		timeZone: undefined, // Uses system time zone by default
 	};
 
 	async onload() {
@@ -132,38 +132,38 @@ export default class YouTrackPlugin extends Plugin {
 		}
 	}
 
-       // Parse list of fields referenced in a template
-       parseFieldListFromTemplate(template: string): string[] {
-               const fields = new Set<string>();
-               const regex = /\$\{([^}]+)\}/g;
-               let match: RegExpExecArray | null;
-               while ((match = regex.exec(template)) !== null) {
-                       const field = match[1].trim();
-                       if (!field || field === "id" || field === "url") {
-                               continue;
-                       }
-                       if (field === "title") {
-                               fields.add("summary");
-                       } else {
-                               fields.add(field);
-                       }
-               }
-               return Array.from(fields);
-       }
+	// Parse list of fields referenced in a template
+	parseFieldListFromTemplate(template: string): string[] {
+		const fields = new Set<string>();
+		const regex = /\$\{([^}]+)\}/g;
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(template)) !== null) {
+			const field = match[1].trim();
+			if (!field || field === "id" || field === "url") {
+				continue;
+			}
+			if (field === "title") {
+				fields.add("summary");
+			} else {
+				fields.add(field);
+			}
+		}
+		return Array.from(fields);
+	}
 
 	formatTimestamp(value: unknown): string {
 		const date = typeof value === "number" ? new Date(value) : new Date(String(value));
 		if (isNaN(date.getTime())) {
 			return String(value);
 		}
-		
+
 		const formatOptions = this.dateTimeOptions;
 		return date.toLocaleString(formatOptions.locale, {
-			timeZone: formatOptions.timeZone
+			timeZone: formatOptions.timeZone,
 		});
 	}
 
-		renderTemplate(template: string, issueId: string, issueUrl: string, issueData: any): string {
+	renderTemplate(template: string, issueId: string, issueUrl: string, issueData: any): string {
 		// Build replacement map
 		const fieldList = this.parseFieldListFromTemplate(template);
 
@@ -189,9 +189,6 @@ export default class YouTrackPlugin extends Plugin {
 				replacements[field] = formatted;
 			}
 		}
-		console.log("Replacements:", replacements);
-		console.log("Template:", template);
-		console.log("Issue Data:", issueData);
 		return template.replace(/\$\{([^}]+)\}/g, (_match, key) => replacements[key] ?? "");
 	}
 
@@ -390,9 +387,9 @@ class YouTrackSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Note template")
-.setDesc(
-"Path to a template file in your vault. Use ${id}, ${title}, ${url} and any issue fields as placeholders (leave empty for default template)"
-)
+			.setDesc(
+				"Path to a template file in your vault. Use ${id}, ${title}, ${url} and any issue fields as placeholders (leave empty for default template)"
+			)
 			.addText(text =>
 				text
 					.setPlaceholder("Template path")
@@ -402,7 +399,6 @@ class YouTrackSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
-
 
 		new Setting(containerEl)
 			.setName("Use API token authentication")


### PR DESCRIPTION
## Summary
- remove `fields` option from plugin settings
- parse placeholders from the template when fetching and rendering
- update settings UI description
- adjust tests accordingly
- document automatic field detection in README

Fixes #11 