### PR TITLE
Add build check in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,3 +16,10 @@ jobs:
         run: |
           yarn install
           yarn build
+      - name: Fail if build modified files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Build modified files. Commit the output of 'yarn build'."
+            git status --porcelain
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
         run: |
           yarn install
           yarn build
+      - name: Fail if build modified files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Build modified files. Commit the output of 'yarn build'."
+            git status --porcelain
+            exit 1
+          fi
       - name: Create plugin archives
         run: |
           mkdir -p obsidian-youtrack-fetcher


### PR DESCRIPTION
## Summary
- fail CI workflows when `yarn build` leaves uncommitted files

## Testing
- `node node_modules/jest/bin/jest.js --runInBand`
- `node node_modules/typescript/bin/tsc -noEmit -skipLibCheck`
- `node esbuild.config.mjs --production`
