### PR TITLE
Add stricter eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,9 @@
       "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",
       "no-prototype-builtins": "off",
-      "@typescript-eslint/no-empty-function": "off"
-    } 
+      "@typescript-eslint/no-empty-function": "off",
+      "no-console": ["error", { "allow": ["error"] }],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error"
+    }
   }


### PR DESCRIPTION
## Summary
- configure eslint to forbid `console.log` but allow `console.error`
- guard against unhandled promises in Obsidian plugin code

## Testing
- `npx jest`
- `npx tsc -noEmit -skipLibCheck`
