### PR TITLE
Restrict build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- trigger CI build only for pushes to `main` and pull requests

## Testing
- `yarn build`