### PR TITLE
Allow entering issue URL

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -55,4 +55,25 @@ describe("YouTrackPlugin Utils", () => {
 			expect(result).toBe("not-a-date");
 		});
 	});
+
+	describe("parseIssueId", () => {
+		beforeEach(async () => {
+			await plugin.loadSettings();
+			plugin.settings.youtrackUrl = "https://youtrack.jetbrains.com";
+		});
+
+		test("should return ID when input is plain ID", () => {
+			expect(plugin.parseIssueId("ABC-1")).toBe("ABC-1");
+		});
+
+		test("should extract ID from matching URL", () => {
+			const url = "https://youtrack.jetbrains.com/issue/ABC-1";
+			expect(plugin.parseIssueId(url)).toBe("ABC-1");
+		});
+
+		test("should return null for mismatched URL", () => {
+			const url = "https://other.com/issue/ABC-1";
+			expect(plugin.parseIssueId(url)).toBeNull();
+		});
+	});
 });

--- a/main.ts
+++ b/main.ts
@@ -146,6 +146,31 @@ export default class YouTrackPlugin extends Plugin {
 
 		return Array.from(fields);
 	}
+
+	parseIssueId(input: string): string | null {
+		const trimmed = input.trim();
+		if (!trimmed) return null;
+
+		if (/^https?:\/\//i.test(trimmed)) {
+			try {
+				const inputUrl = new URL(trimmed);
+				const baseUrl = new URL(this.settings.youtrackUrl);
+				const basePath = baseUrl.pathname.replace(/\/$/, "");
+				const prefix = `${basePath}/issue/`;
+
+				if (inputUrl.origin !== baseUrl.origin || !inputUrl.pathname.startsWith(prefix)) {
+					return null;
+				}
+
+				const id = inputUrl.pathname.substring(prefix.length).split("/")[0];
+				return id || null;
+			} catch {
+				return null;
+			}
+		}
+
+		return trimmed;
+	}
 	formatTimestamp(value: unknown): string {
 		const date = typeof value === "number" ? new Date(value) : new Date(String(value));
 		if (isNaN(date.getTime())) {
@@ -249,7 +274,7 @@ class YouTrackIssueModal extends Modal {
 		// Create input field for issue ID
 		const inputContainer = contentEl.createDiv();
 		const input = new TextComponent(inputContainer)
-			.setPlaceholder("Issue ID (e.g., ABC-123)")
+			.setPlaceholder("Issue URL or ID (e.g., ABC-123)")
 			.setValue(this.issueId || "")
 			.onChange(value => {
 				this.issueId = value;
@@ -292,7 +317,14 @@ class YouTrackIssueModal extends Modal {
 
 		const fetchIssue = async () => {
 			if (!this.issueId) {
-				this.statusEl.setText("Please enter an issue ID");
+				this.statusEl.setText("Please enter an issue ID or URL");
+				this.statusEl.addClass("error-message");
+				return;
+			}
+
+			const parsedId = this.plugin.parseIssueId(this.issueId);
+			if (!parsedId) {
+				this.statusEl.setText("Issue URL does not match the YouTrack URL in settings");
 				this.statusEl.addClass("error-message");
 				return;
 			}
@@ -315,10 +347,10 @@ class YouTrackIssueModal extends Modal {
 			this.statusEl.setText("");
 
 			try {
-				const response: unknown = await this.plugin.fetchIssueData(this.issueId);
+				const response: unknown = await this.plugin.fetchIssueData(parsedId);
 				if (typeof response === "object" && response !== null) {
 					const issueData = response as Record<string, unknown>;
-					await this.plugin.createIssueNote(this.issueId, issueData);
+					await this.plugin.createIssueNote(parsedId, issueData);
 				} else {
 					throw new Error("Invalid response format from YouTrack API");
 				}


### PR DESCRIPTION
## Summary
- support parsing YouTrack issue ID from a pasted URL
- validate that the URL matches the configured YouTrack instance
- show clearer placeholder and error messages
- add unit tests for `parseIssueId`

## Testing
- `yarn format`
- `yarn typecheck`
- `yarn dev`
- `yarn test`
