### PR TITLE
Update docs for linting and URL input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This file provides guidance to AI agents when working with code in this reposito
 - `yarn prod` - Production build without tests or type checking
 - `yarn typecheck` — TypeScript typecheck
 - `yarn format` - Format code with Prettier
+- `yarn lint` - Check code style with ESLint
 - `yarn test` - Run Jest tests
 - `yarn test:dev` - Run development build and then tests
 - `yarn test:watch` - Run development build and then tests in watch mode

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Obsidian plugin allows you to quickly fetch YouTrack issues and create note
 
 ## Features
 
-- Fetch YouTrack issues by ID and create structured notes
+- Fetch YouTrack issues by ID or URL and create structured notes
 - Easy access via keyboard shortcut
 - API token authentication support
 - Configurable folder for storing issue notes
@@ -38,7 +38,7 @@ This Obsidian plugin allows you to quickly fetch YouTrack issues and create note
    ![plugin settings](images/settings.png "Plugin Settings")
 3. Use the keyboard shortcut or click the clipboard icon in the ribbon
    ![fetch issue window](images/modal.png "Fetch Issue Window")
-4. Enter the issue ID
+4. Enter the issue ID or paste the full issue URL
 5. Click "Fetch Issue" to create a note based on the issue data
    ![fetched issue](images/fetched.png "Fetched Issue")
 
@@ -82,6 +82,12 @@ Run the TypeScript type check:
 
 ```shell
 yarn typecheck
+```
+
+Run the linter:
+
+```shell
+yarn lint
 ```
 
 Run the tests:


### PR DESCRIPTION
## Summary
- document new ability to paste issue URLs
- mention the lint script in the development docs
- add lint command to CLAUDE guidance

## Testing
- `yarn lint`
- `yarn typecheck`
- `CI=true yarn test`