### PR TITLE
Add Jest coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Run the tests in watch mode:
 yarn test:watch
 ```
 
+Generate a coverage report:
+
+```shell
+yarn coverage
+```
+
 Run the production build (includes tests, type checking, and formatting):
 
 ```shell

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,13 @@ module.exports = {
 	testEnvironment: "jsdom",
 	transform: {
 		...tsJestTransformCfg,
-	},
+       },
+	coverageProvider: "v8",
+	coverageDirectory: "coverage",
+	collectCoverageFrom: [
+		"**/*.ts",
+		"!**/*.test.ts",
+		"!**/__tests__/**",
+		"!node_modules/**",
+	],
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test": "jest",
 		"test:dev": "yarn dev && jest",
 		"test:watch": "yarn dev && jest --watch",
+		"coverage": "yarn dev && jest --coverage",
 		"lint": "eslint .",
 		"build": "yarn typecheck && yarn lint && yarn format && yarn prod && yarn test",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",


### PR DESCRIPTION
## Summary
- collect coverage when running Jest tests
- add `yarn coverage` script
- document how to generate a coverage report

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test:dev`
- `yarn coverage`
