### PR TITLE
Hide token in settings

### DIFF
--- a/src/YouTrackSettingTab.ts
+++ b/src/YouTrackSettingTab.ts
@@ -77,15 +77,16 @@ export default class YouTrackSettingTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setName("API token")
 				.setDesc("Permanent API token for YouTrack authentication")
-				.addText(text =>
+				.addText(text => {
 					text
 						.setPlaceholder("Enter your API token")
 						.setValue(this.plugin.settings.apiToken)
 						.onChange(async value => {
 							this.plugin.settings.apiToken = value;
 							await this.plugin.saveSettings();
-						})
-				)
+						});
+					text.inputEl.type = "password";
+				})
 				.addExtraButton(button =>
 					button.setIcon("help").onClick(() => {
 						const helpUrl = "https://www.jetbrains.com/help/youtrack/server/manage-permanent-token.html";


### PR DESCRIPTION
## Summary
- use password field for the API token

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_687ab9ca9e448332a631f0e3b883e98b