### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/obsidian-youtrack-fetcher/security/code-scanning/1](https://github.com/forketyfork/obsidian-youtrack-fetcher/security/code-scanning/1)

To fix this issue, we should add a `permissions` block to the workflow to explicitly define the privileges needed for the job. Based on the workflow's current operations (e.g., checking out the repository, installing dependencies, and building the plugin), we can safely restrict permissions to `contents: read`. This grants the required read access to the repository contents while preventing unnecessary write access.

The `permissions` block can be added at the job level (specific to `build`) or at the root level of the workflow to apply it to all jobs within the workflow. For simplicity and clarity, we'll add the `permissions` block at the root level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
