### PR TITLE
Align Node.js version to 24.x across all environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "18.x"
+          node-version: "24.x"
       - name: Build plugin
         run: |
           yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "18.x"
+          node-version: "24.x"
       - name: Build plugin
         run: |
           yarn install

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             # Node.js and package manager
-            nodejs_20
+            nodejs_24
             yarn
 
             # Development tools


### PR DESCRIPTION
## Summary
- Updates flake.nix to use nodejs_24 instead of nodejs_20 for local development
- Updates GitHub Actions workflows to use Node.js 24.x instead of 18.x for CI
- Ensures consistent Node.js version between local development and CI environments

## Test plan
- [x] Verify flake.nix uses nodejs_24
- [x] Verify all GitHub Actions workflows use Node.js 24.x
- [ ] Test GitHub Actions workflows on PR
- [ ] Verify Nix development environment works with Node.js 24