### PR TITLE
ci: add artifact attestation to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
@@ -26,12 +29,13 @@ jobs:
             git status --porcelain
             exit 1
           fi
-      - name: Create plugin archives
-        run: |
-          mkdir -p obsidian-youtrack-fetcher
-          cp main.js manifest.json styles.css obsidian-youtrack-fetcher/
-          zip -r obsidian-youtrack-fetcher.zip obsidian-youtrack-fetcher/
-          tar -czf obsidian-youtrack-fetcher.tar.gz obsidian-youtrack-fetcher/
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,4 +45,4 @@ jobs:
           gh release create "$tag" \
             --title="$tag" \
             --draft \
-            main.js manifest.json styles.css obsidian-youtrack-fetcher.zip obsidian-youtrack-fetcher.tar.gz
+            main.js manifest.json styles.css


### PR DESCRIPTION
## Summary

Adds signed SLSA build provenance attestations to the release workflow using `actions/attest@v4`. Also drops the unsupported `.zip` and `.tar.gz` archive assets, since Obsidian only loads `main.js`, `manifest.json`, and `styles.css`.

After this lands, every tagged release ships those three files, each with a signed attestation that can be verified with `gh attestation verify`.

## Test plan

- [ ] Cut a test tag and confirm the "Attest build provenance" step succeeds in the Actions run
- [ ] Download `main.js` from the resulting draft release and run `gh attestation verify main.js -R forketyfork/obsidian-youtrack-fetcher`
- [ ] Confirm the draft release contains only `main.js`, `manifest.json`, `styles.css`
